### PR TITLE
Minor NLog.config fix

### DIFF
--- a/src/SteamSpy/NLog.config
+++ b/src/SteamSpy/NLog.config
@@ -1,22 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd"
-      autoReload="true"
-      throwExceptions="false"
-      internalLogLevel="Off" internalLogFile="c:\temp\nlog-internal.log">
-
-  <!-- optional, add some variables
-  https://github.com/nlog/NLog/wiki/Configuration-file#variables
-  -->
-  <variable name="myvar" value="myvalue"/>
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <targets>
-    <target xsi:type="File" name="logFile" fileName="${basedir}/LauncherFiles/logs/${shortdate}.log"
-      layout="${longdate} | ${uppercase:${level}} | ${logger} | ${message}" />
+    <target name="logfile" xsi:type="File" fileName="${basedir}/LauncherFiles/logs/${shortdate}.log"
+      layout="${longdate} | ${uppercase:${level}} | ${logger} | ${message}"
+            maxArchiveFiles="5"
+            archiveAboveSize="10000"
+            archiveEvery="Day"/>
+    <target name="logconsole" xsi:type="Console" />
   </targets>
 
   <rules>
-    <logger name="*" minlevel="Info" writeTo="logFile" />
+    <logger name="*" minlevel="Info" writeTo="logfile" />
   </rules>
 </nlog>


### PR DESCRIPTION
Ругался, что отсутствовал путь, куда логгер должен писать свой лог +решил немного порефакторить. Думаю, стоит ограничить максимальный размер логов в 40 метров у пользователей лаунчера, дабы не наткнуться на жалобы в дальнейшем