### PR TITLE
Mod detector

### DIFF
--- a/src/SteamSpy/Services/Implementations/SingleClientServer.cs
+++ b/src/SteamSpy/Services/Implementations/SingleClientServer.cs
@@ -255,6 +255,7 @@ namespace ThunderHawk
             if (message.StartsWith("JOIN", StringComparison.OrdinalIgnoreCase)) { HandleRemoteJoinCommand(values); return; }
             if (message.StartsWith("SETCKEY", StringComparison.OrdinalIgnoreCase)) { HandleRemoteSetckeyCommand(values); return; }
 
+            
             Debugger.Break();
         }
 
@@ -483,6 +484,18 @@ namespace ThunderHawk
 
         void HandleLogin(TcpClientNode node, Dictionary<string, string> pairs)
         {
+
+            string userMode = ActiveModDetector.detectCurrentMode();
+
+            if (userMode.StartsWith("thunderhawk"))
+            {
+                Logger.Info("Чел входит с нужным модом(" + userMode +") всё в порядке");
+            }
+            else
+            {
+                Logger.Warn("Alarm! кто-то пытается войти с модом "+ userMode +" и поломать автоматч!");   
+            }
+            
             if (pairs.ContainsKey("uniquenick"))
                 _name = pairs["uniquenick"];
             else

--- a/src/SteamSpy/StaticClasses/Soulstorm/ActiveModDetector.cs
+++ b/src/SteamSpy/StaticClasses/Soulstorm/ActiveModDetector.cs
@@ -1,0 +1,44 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using ThunderHawk.Core;
+using NLog;
+using Logger = ThunderHawk.Core.Logger;
+
+namespace ThunderHawk.StaticClasses.Soulstorm
+{
+    public static class ActiveModDetector
+    {
+        public static string detectCurrentMode()
+        {
+            try
+            {
+                //Open the stream and read it back.
+                FileInfo soulstormConsole = new FileInfo(PathFinder.GamePath + "\\warnings.log");
+
+                var activeMod = "Not found";
+                
+                using (var streamReader = new StreamReader(soulstormConsole.Open(FileMode.Open, FileAccess.Read, FileShare.ReadWrite)))
+                {
+                    while (streamReader.Peek() > -1) 
+                    {
+                        string line = streamReader.ReadLine();
+                        if (line != null && line.Contains("MOD -- Initializing Mod"))
+                        {
+                            activeMod = line.Substring(38);
+                        }
+                    }
+                    return activeMod;
+                }
+                    
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e);
+                return "Can't find active mode: " + e.Message;
+            }
+            
+        }
+    }
+}


### PR DESCRIPTION
Топорным способом определяет запущенный мод перед входом на сервер. Сильно грузить не должно, т.к. читает 1 раз.